### PR TITLE
Allow manual triggering of mod list refresh

### DIFF
--- a/.github/workflows/update-action.yml
+++ b/.github/workflows/update-action.yml
@@ -5,6 +5,8 @@ on:
       - 'master'
   schedule:
   - cron: '*/20 * * * *'
+  issue_comment:
+    types: [ edited ]
 
 jobs:
   test:


### PR DESCRIPTION
GitHub scheduled jobs can be widely inconsistent, often taking over an hour between runs. This is annoying when someone is waiting on MMM to update before posting a mod. This change updates the list whenever a issue comment is edited (to reduce the chance of random triggering), to allow mod creators to manually trigger a refresh of mods, bypassing the waiting period.